### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Bugtags Android SDK
 ===================
 [ ![Download](https://api.bintray.com/packages/bugtags/maven/bugtags-lib/images/download.svg) ](https://bintray.com/bugtags/maven/bugtags-lib/_latestVersion)
-###中文文档请移步 [README_CN](README_CN.md)
-###QQ tribe for help: 210286347
+### 中文文档请移步 [README_CN](README_CN.md)
+### QQ tribe for help: 210286347
 
 [Bugtags] for Android, reports bugs and their diagnosis information in one step, captures crashes automatically. Improve your apps anywhere, anytime.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,7 +1,7 @@
 Bugtags Android SDK
 ===================
 [ ![Download](https://api.bintray.com/packages/bugtags/maven/bugtags-lib/images/download.svg) ](https://bintray.com/bugtags/maven/bugtags-lib/_latestVersion)
-###帮助QQ群: 210286347
+### 帮助QQ群: 210286347
 
 [Bugtags]，为移动测试而生，随时随地改善你的移动应用。只需一步，提交 bug 及其上下文数据，自动捕捉崩溃，让修复 bug 更简单。
 
@@ -154,7 +154,7 @@ Bugtags Android SDK
   # End Bugtags
 ```
 
-###编译运行 App，将会在 App 内部看到一个小球，成功了!###
+### 编译运行 App，将会在 App 内部看到一个小球，成功了! ###
 
 # Change log
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
